### PR TITLE
Fix stream_select() error when sockets are empty

### DIFF
--- a/_posts/2012-12-22-Cooperative-multitasking-using-coroutines-in-PHP.markdown
+++ b/_posts/2012-12-22-Cooperative-multitasking-using-coroutines-in-PHP.markdown
@@ -546,6 +546,10 @@ ready and reschedules the respective tasks:
 
 ```php?start_inline=1
 protected function ioPoll($timeout) {
+    if (empty($this->waitingForRead) && empty($this->waitingForWrite)) {
+        return;
+    }
+    
     $rSocks = [];
     foreach ($this->waitingForRead as list($socket)) {
         $rSocks[] = $socket;


### PR DESCRIPTION
When the server receives an incoming message, it adds a new task for handling the request. After that, there is a time window when the read and write sockets are empty and the next call of stream_select fails.

Added check [alredy exist](https://github.com/nikic/ditaio/blob/master/lib/Scheduler.php#L71-L73) in your repo