### PR TITLE
Twitter: strip link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,8 +23,7 @@
         <header>
             Blog by <strong>nikic</strong>.
             Find me on <a href="https://github.com/nikic">GitHub</a>,
-            <a href="https://stackoverflow.com/users/385378/nikic">StackOverflow</a>
-            and <a href="http://twitter.com/nikita_ppv">Twitter</a>.
+            <a href="https://stackoverflow.com/users/385378/nikic">StackOverflow</a>.
             Learn more <a href="/aboutMe.html">about me</a>.
         </header>
         <section>


### PR DESCRIPTION
It's probably best to leave out the link to X (formerly Twitter), in light of not-so-recent events.